### PR TITLE
Reorganize SensuFlow readme

### DIFF
--- a/docs/BITBUCKET.md
+++ b/docs/BITBUCKET.md
@@ -1,41 +1,45 @@
 ## Bitbucket
-The `sensu/sensu-flow` [Docker container image](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#define-image-in-the-gitlab-ciyml-file) can be used with Bitbucket pipelines. The `sensuflow.sh` script within this container was originally developed for GitHub actions, but will execute successfully if provided the correct environment variables.
+
+You can use the `sensu/sensu-flow` [Docker container image][2] with [Bitbucket pipelines][1].
 
 ### Authentication
 
-The `sensuflow.sh` script will look for a `SENSU_API_URL` and `SENSU_API_KEY` to use for authentication, and while it is possible to add these directly to your `bitbucket-pipelines.yml` file, we recommend using [Bitbucket repository variables](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/) in order to keep your credentials from being tracked by git. 
+The `sensuflow.sh` script requires the SENSU_API_KEY and SENSU_API_URL [environment variables][4] for authentication.
 
-To set repository variables, from your repository's page on Bitbucket, click on "Repository settings" on the left-hand menu. From there, click on "Repository variables," also on the left-hand menu.
+The SENSU_API_KEY is the Sensu [API key for your sensu-flow service account user][6].
+The SENSU_API_URL is the Sensu backend URL used to configure sensuctl.
+For example, if your Sensu backend is hosted at `93.184.216.34` on port `8080`, the SENSU_API_URL is `http://93.184.216.34:8080`.
 
-On the resulting page, in the "Name" input bux, put `SENSU_API_URL`. Set the "Value" input box to be the API URL of your backend. For example, if your Sensu backend is hosted at `93.184.216.34` on port `8080`, you would set `SENSU_API_URL` to `http://93.184.216.34:8080`. Leave the "Secured" checkbox checked, and click the "Add" button.
+Although you can add the SENSU_API_KEY and SENSU_API_URL directly to your `bitbucket-pipelines.yml` file, we recommend using [Bitbucket repository variables][3] for sensitive information like authentication credentials.
 
-After that is done, you will add `SENSU_API_KEY` in the same way. To generate your API key, in an environment where you have `sensuctl` configured, run `sensuctl api-key grant sensu-flow`. This will output a string such as the following.
+To set Bitbucket repository variables:
 
-```
-/api/core/v2/apikeys/4b044eea-9937-4e83-b263-2f6cd0431e9c
-```
+1. On your repository's page on Bitbucket, use the left menu to navigate to **Repository settings > Repository variables**.
+Wait for the Repository variables page to load.
 
-The final part, `4b044eea-9937-4e83-b263-2f6cd0431e9c` is what you will set as the value of `SENSU_API_KEY`. If you encounter an error, make sure that a `sensu-flow` user has been created [as is specified](https://github.com/sensu/sensu-flow#create-the-sensu-flow-user) in this repository's main documentation.
+2. In the *Name* field, enter `SENSU_API_KEY`.
+
+3. In the *Value* field, enter the API key for your sensu-flow service account user.
+
+4. Ensure that the *Secured* checkbox is checked.
+
+5. Click **Add**.
+
+6. Repeat steps 1 through 5 for the SENSU_API_URL variable and value.
 
 ### Other Configuration Options
 
-The following environment variables are taken into account by `sensuflow.sh`. You can either set them using Bitbucket repository variables in the same way as described in the "Authentication" section above, or you can set them directly in your script by executing `export VARIABLE=VALUE`. For example, to set `VERBOSE` to `1`, you would add `export VERBOSE=1` to your pipeline script.
+In addition to the required environment variables, SensuFlow includes optional environment variables.
+You can set the optional environment variables with Bitbucket repository variables as described in [Authentication][7] or directly in your Bitbucket pipeline script.
 
-* `SENSU_CA` - CA certificate as a string.
-* `SENSU_CA_FILE` - CA certificate file, if set overrides `SENSU_CA`.
-* `CONFIGURE_OPTIONS` - Additional sensuctl configure options.
-* `NAMESPACES_DIR` - Directory holding sensuflow namepace subdirectories.
-* `NAMESPACES_FILE` - File holding namespace resource definitions sensuflow action should create.
-* `MANAGED_RESOURCES` - A comma seperated list of resources.
-* `MATCHING_LABEL` - A resource label to match.
-* `MATCHING_CONDITION` - Condition to match.
-* `DISABLE_SANITY_CHECKS` - If set sanity checks will be disabled.
-* `DISABLE_TLS_VERIFY` - If TLS verification will be disabled.
-* `VERBOSE` - If set shows verbose description of actions carried out by the script.
+To set environment variables in your Bitbucket pipeline script, add `export VARIABLE=VALUE`.
+For example, to set `VERBOSE` to `1`, add `export VERBOSE=1` to your pipeline script.
 
-### Example Pipeline
+### Example Bitbucket pipeline
 
-Create a file named `bitbucket-pipelines.yml` in the root folder of your project with the following contents, and edit it as needed. The example below is set to show verbose output, and to load the credentials necessary for authentication from Bitbucket repository variables. 
+Create a file named `bitbucket-pipelines.yml` in the root folder of your project with the following contents and edit as needed.
+This example shows verbose output and loads the credentials necessary for authentication from Bitbucket repository variables. 
+
 
 ```yaml
 image: sensu/sensu-flow:0.6.0
@@ -43,8 +47,18 @@ image: sensu/sensu-flow:0.6.0
 pipelines:
   default:
     - step:
-        name: 'Sensuflow with required settings'
+        name: 'SensuFlow with required settings'
         script:
           - "export VERBOSE=1"
           - "/sensuflow.sh"
 ```
+
+
+[1]: https://confluence.atlassian.com/bitbucket/use-docker-images-as-build-environments-in-bitbucket-pipelines-792298897.html
+[2]: https://hub.docker.com/repository/docker/sensu/sensu-flow
+[3]: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
+[4]: ../#configuration
+[5]: ../#create-the-sensu-flow-user
+[6]: ../#api-key-for-the-sensu-flow-user
+[7]: #authentication
+[8]: ../#set-environment-variables

--- a/docs/GITHUB.md
+++ b/docs/GITHUB.md
@@ -1,0 +1,151 @@
+## GitHub
+
+You can use SensuFlow to manage Sensu resources as part of GitHub-facilitated CI/CD workflows.
+SensuFlow was originally designed as a GitHub action.
+
+### Authentication
+
+The `sensuflow.sh` script requires the SENSU_API_KEY and SENSU_API_URL [environment variables][3] for authentication.
+
+The SENSU_API_KEY is the Sensu [API key for your sensu-flow service account user][4].
+The SENSU_API_URL is the Sensu backend URL used to configure sensuctl.
+For example, if your Sensu backend is hosted at `93.184.216.34` on port `8080`, the SENSU_API_URL is `http://93.184.216.34:8080`.
+
+We recommend using [GitHub Actions secrets][3] for sensitive information like authentication credentials.
+
+### Configure the SensuFlow GitHub Action
+
+Use this GitHub Action as part of a GitHub Action workflow YAML definition.
+GitHub Action workflow definitions are placed in `.github/workflows/` in your code repository and must exist in the default branch.
+Read the [GitHub Actions documentation][2] for more information.
+
+### Example GitHub Action
+
+This section describes a working example that will run the SensuFlow GitHub Action when you push to the `main` branch of your code repository or when anyone creates a pull request against the `main` branch.
+
+1. Save the following code as `.github/workflows/sensu-flow.yaml` and commit it to the `main` branch of your code repository:
+
+```
+name: SensuFlow CI Example
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  # Defined the SensuFlow job 
+  SensuFlow:
+    runs-on: ubuntu-latest
+    steps:
+    # Step 1: Checks-out your repository, so your job can access it
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    # Step 2: use the versioned sensu/sensu-flow action 
+    - name: Sensuflow with required settings
+      uses: sensu/sensu-flow@0.6.0
+      with:
+        # Required configuration
+        # Please make use of GitHub secrets for sensitive information 
+        sensu_api_url: ${{ secrets.SENSU_API_URL }}
+        sensu_api_key: ${{ secrets.SENSU_API_KEY }}
+        # Optional configuration, if not present defaults will be used
+        namespaces_dir: .sensu/namespaces
+        namespaces_file: .sensu/cluster/namespaces.yaml
+        matching_label: "sensu.io/workflow"
+        matching_condition: "== 'sensu-flow'"
+
+```
+
+2. Add the following definition for a new Sensu namespace resource to the file `.sensu/cluster/namespaces.yaml` in your code repository:
+
+```
+---
+type: Namespace
+api_version: core/v2
+spec:
+  name: test-namespace
+```
+
+3. Create a corresponding namespace directory for the new `test-namespace` resource:
+
+```
+mkdir -p .sensu/namespaces/test-namespace
+touch .sensu/namespaces/.keep
+``` 
+
+The SensuFlow GitHub Action will process the `test-namespace` directory, using any resource definitions it finds within that directory as a source of truth for the state of the corresponding Sensu namespace.
+The `.keep` file tells git to keep the directory structure as part of the repository even if there are no files defined in it.
+
+4. Create `checks` and `handlers` subdirectories within the `test-namespace` directory:
+```
+mkdir .sensu/namespaces/test-namespace/checks
+mkdir .sensu/namespaces/test-namespace/handlers
+``` 
+
+5. Create a file named `.sensu/namespaces/test-namespace/checks/hello_world.yaml` and save the following check resource in it:
+
+```
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: hello_world
+  labels:
+    sensu.io/workflow: sensu-flow
+spec:
+  command: echo "hello world"
+  interval: 30
+  publish: false
+  subscriptions:
+  - test
+  timeout: 10
+```
+
+5. Create a file named `.sensu/namespaces/test-namespace/handlers/test.yaml` and save the following handler resource in it:
+
+```
+type: Handler
+api_version: core/v2
+metadata:
+  name: test
+  labels:
+    sensu.io/workflow: sensu-flow
+spec:
+  command: sleep 10
+  type: pipe
+```
+
+6. Commit and push the changes to your GitHub code repository.
+The SensuFlow GitHub Action should trigger and run to completion.
+
+7. As the administrative user for your Sensu environment, verify that the `test-namespace` namespace exists:
+
+```
+sensuctl namespace list
+```
+
+8. Verify that the `hello-world` check, and `test` handler were created within the `test-namespace`:
+
+```
+sensuctl --namespace test-namespace check list
+sensuctl --namespace test-namespace handler list
+```
+
+9. Delete the file `.sensu/namespaces/test-namespace/checks/hello_world.yaml` in your Sensu environment.
+
+10. Commit and push the change to you rGitHub code repository.
+The SensuFlow GitHub Action will use `sensuctl prune` to remove the `hello-world` check.
+
+11. Verify that the `hello-world` check no longer exists in the `test-namespace`:
+
+```
+sensuctl --namespace test-namespace check list
+```
+
+
+[1]: https://docs.github.com/en/github-ae@latest/actions/security-guides/encrypted-secrets
+[2]: https://docs.github.com/en/github-ae@latest/actions
+[3]: ../#configuration
+[4]: ../#api-key-for-the-sensu-flow-user

--- a/docs/GITLAB.md
+++ b/docs/GITLAB.md
@@ -1,31 +1,21 @@
 ## GitLab
-You can use the `sensu/sensu-flow` [Docker container image](https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#define-image-in-the-gitlab-ciyml-file) with GitLab. This container image includes everything needed to run the `sensuflow.sh` script originally developed for GitHub actions. Please note, it's a good idea to use GitLab's support for [Vault Secrets](https://docs.gitlab.com/ee/ci/yaml/index.html#secrets) for sensitive authentication variables such as the Sensu api key or password.
 
-### Important environment variables
-When using the docker image with GitLab, you'll need to be aware of several environment variables used by the `sensuflow.sh` script run within the Docker container. These variables are documented in the `sensuflow.sh` header comments, but here's a quick summary for reference.
+You can use the `sensu/sensu-flow` [Docker container image][2] with [GitLab CI/CD][1].
 
-```
-## Required Environment Variables
-# SENSU_API_URL: sensu backend api url used by sensuctl
-# SENSU_API_KEY: sensu api key for sensuctl, used instead of user and password above
-## Optional Environment Variables
-# SENSU_CA: CA certificate as a string
-# SENSU_CA_FILE: CA certificate file, if set overrides SENSU_CA
-# CONFIGURE_OPTIONS: Additional sensuctl configure options
-# NAMESPACES_DIR: directory holding sensuflow namepace subdirectories
-# NAMESPACES_FILE: file holding namespace resource definitions sensuflow action should create
-# MANAGED_RESOURCES: comma seperated list of resources
-# MATCHING_LABEL: resource label to match
-# MATCHING_CONDITION: condition to match
-# DISABLE_SANITY_CHECKS: if set disable sanity checks
-# DISABLE_TLS_VERIFY: if set disable TLS verification 
-## Deprecated Authentication Environment Variables
-# SENSU_USER: sensu user for sensuctl configue (deprecated, use SENSU_API_KEY)
-# SENSU_PASSWORD: sensu password for sensuctl configure (deprecated, use SENSU_API_KEY)
-```
+### Authentication
 
-### Reference GitLab CI/CD job definition
-Here's a reference example for a GitLab CI/CD job definition making use of the `sensu/sensu-flow` docker image together with an api-key seeded into a vault.
+The `sensuflow.sh` script requires the SENSU_API_KEY and SENSU_API_URL [environment variables][4] for authentication.
+
+The SENSU_API_KEY is the Sensu [API key for your sensu-flow service account user][6].
+The SENSU_API_URL is the Sensu backend URL used to configure sensuctl.
+For example, if your Sensu backend is hosted at `93.184.216.34` on port `8080`, the SENSU_API_URL is `http://93.184.216.34:8080`.
+
+Although you can add the SENSU_API_KEY and SENSU_API_URL directly to your `.gitlab-ci.yml` file, we recommend using [GitLab CI/CD secrets][3] for sensitive information like authentication credentials.
+
+### Example GitLab CI/CD job definition
+
+Here's a reference example for a GitLab CI/CD job definition that uses the `sensu/sensu-flow` Eocker image with an api-key seeded into a vault.
+
 ```
 stages:
   - deploy
@@ -48,3 +38,8 @@ sensu_flow:
   variables:
     VERBOSE: "1"
 ```
+
+
+[1]: https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#define-image-in-the-gitlab-ciyml-file
+[2]: https://hub.docker.com/repository/docker/sensu/sensu-flow
+[3]: https://docs.gitlab.com/ee/ci/yaml/index.html#secrets


### PR DESCRIPTION
Reorganizes content in the existing readme as well as pages in https://github.com/sensu/sensu-flow/tree/main/docs.

- Separates GitHub Action-specific info into a separate page within the /docs directory
- Rearranges readme content under logical headings
- Revises and updates readme content and info in CI/CD-specific /docs pages
- Adds some info taken from https://sensu.io/blog/monitoring-as-code-with-sensu-flow

Closes https://github.com/sensu/sensu-flow/issues/44